### PR TITLE
修复未开启自动重连时编译不通过问题

### DIFF
--- a/mport/firmware.c
+++ b/mport/firmware.c
@@ -10,7 +10,7 @@ int request_firmware(const struct firmware **fw, const char *file)
     result = stat(file, &st);
     if (result < 0)
     {
-        rt_kprintf("firmware:[%s] not found!\n");
+        rt_kprintf("firmware:[%s] not found!\n", file);
         return -RT_ERROR;
     }
 

--- a/mwifi.c
+++ b/mwifi.c
@@ -239,6 +239,7 @@ rt_err_t mwifi_powersave(struct net_device *ndev, int enabled)
     return ret;
 }
 
+#if defined(REASSOCIATION)
 rt_err_t mwifi_reassociation(struct net_device *ndev, int enabled)
 {
     struct ifreq ifr;
@@ -262,6 +263,7 @@ rt_err_t mwifi_reassociation(struct net_device *ndev, int enabled)
 
     return ret;
 }
+#endif
 
 rt_err_t mwifi_set_region(struct net_device *ndev, const char *country)
 {
@@ -411,6 +413,7 @@ int cmd_mwifi(int argc, char **argv)
                 }
                 mwifi_powersave(ndev, enabled);
             }
+#if defined(REASSOCIATION)
             else if (!strcmp("reassoc", argv[2]))
             {
                 int enabled = -1;
@@ -432,6 +435,7 @@ int cmd_mwifi(int argc, char **argv)
                 }
                 mwifi_reassociation(ndev, enabled);
             }
+#endif
             else if (!strcmp("region", argv[2]) && argc == 4)
                 mwifi_set_region(ndev, argv[3]);
             else


### PR DESCRIPTION
缺陷描述：如果wifi固件文件不存在可能导致异常
问题原因：rt_kprintf中%s缺少参数
解决思路：增加file打印参数
涉及文件：./mport/firmware.c

缺陷2：
缺陷描述：不开启WIFI重连功能的情况下编译不通过
问题原因：WOAL_SET_GET_REASSOC宏被屏蔽，导致mwifi_reassociation函数编译不通过
解决思路：增加宏屏蔽，如果未开启，直接屏蔽mwifi_reassociation及其调用
涉及文件：./mwifi.c