### PR TITLE
修改执行mwifi_scan可能出现内存异常的问题；

### DIFF
--- a/mwifi.c
+++ b/mwifi.c
@@ -207,11 +207,13 @@ rt_err_t mwifi_disconnect(struct net_device *ndev)
 rt_err_t mwifi_scan(struct net_device *ndev)
 {
     union iwreq_data uwrq;
+    char cmd_buf[sizeof(WEXT_CSCAN_HEADER)] = {0};
     rt_err_t ret = -RT_ERROR;
 
     RT_ASSERT(ndev);
 
-    uwrq.data.pointer = WEXT_CSCAN_HEADER;
+	memcpy(cmd_buf, WEXT_CSCAN_HEADER, sizeof(cmd_buf));
+    uwrq.data.pointer = cmd_buf;
     uwrq.data.length = WEXT_CSCAN_HEADER_SIZE;
     ret = ndev->wireless_handlers->standard
           [IW_IOCTL_IDX(SIOCSIWPRIV)](ndev, NULL, &uwrq, NULL);

--- a/mwifi.c
+++ b/mwifi.c
@@ -212,7 +212,7 @@ rt_err_t mwifi_scan(struct net_device *ndev)
 
     RT_ASSERT(ndev);
 
-	memcpy(cmd_buf, WEXT_CSCAN_HEADER, sizeof(cmd_buf));
+    memcpy(cmd_buf, WEXT_CSCAN_HEADER, sizeof(cmd_buf));
     uwrq.data.pointer = cmd_buf;
     uwrq.data.length = WEXT_CSCAN_HEADER_SIZE;
     ret = ndev->wireless_handlers->standard


### PR DESCRIPTION
修改mwifi_scan函数给uwrq.data.pointer一个内存空间，防止在woal_set_priv函数执行成功将内容为"OK\n"的buf拷贝到dwrq->pointer时内存异常；